### PR TITLE
Update landing page filter 

### DIFF
--- a/sessions.view.lkml
+++ b/sessions.view.lkml
@@ -85,8 +85,16 @@ view: sessions {
     group_label: "URL Information"
     case: {
       when: {
-        label: "Blog"
-        sql: ${landing_page} like '%blogs/%'  ;;
+        label: "Blog-Thinx"
+        sql: ${landing_page} like '%blogs/%' AND ${landing_page} like '%/thinx%';;
+      }
+      when: {
+        label: "Blog-Speax"
+        sql: ${landing_page} like '%blogs/%' AND ${landing_page} like '%/speax%';;
+      }
+      when: {
+        label: "Blog-BTWN"
+        sql: ${landing_page} like '%blogs/%' AND ${landing_page} like '%/btwn%';;
       }
       when: {
         label: "BTWN"

--- a/sessions.view.lkml
+++ b/sessions.view.lkml
@@ -85,16 +85,16 @@ view: sessions {
     group_label: "URL Information"
     case: {
       when: {
-        label: "Blog-Thinx"
-        sql: ${landing_page} like '%blogs/%' AND ${landing_page} like '%/thinx%';;
+        label: "Blog-BTWN"
+        sql: ${landing_page} like '%blogs/%' AND ${landing_page} like '%btwn%';;
       }
       when: {
         label: "Blog-Speax"
-        sql: ${landing_page} like '%blogs/%' AND ${landing_page} like '%/speax%';;
+        sql: ${landing_page} like '%blogs/%' AND ${landing_page} like '%speax%';;
       }
       when: {
-        label: "Blog-BTWN"
-        sql: ${landing_page} like '%blogs/%' AND ${landing_page} like '%/btwn%';;
+        label: "Blog-Thinx"
+        sql: ${landing_page} like '%blogs/%';;
       }
       when: {
         label: "BTWN"


### PR DESCRIPTION
## ✨ Summary:
_A brief/high-level description of changes being made._
Update landing page filter

## 🔍 Reason/Impact:
_Why are changes being made? Who requested changes? Was there a bug?_
Performance marketing team wants to be able to split out blog landing page category by brand -- i.e. Thinx, Speax, BTWN

## 📝 Description:
Details about what is changing - include specific fields, metrics, etc.
Change landing page logic to separate blogs by brand -- creating `Blog-Thinx`, `Blog-BTWN` and `Blog-Speax` fields for filtering, etc. 

## ✅ Testing:
_How do you know it works? Include screenshots/metrics etc. comparing dev mode to production._
New:
![Screen Shot 2020-06-15 at 5 06 32 PM](https://user-images.githubusercontent.com/47616998/84706643-53a50680-af2b-11ea-8b15-da2b071aa29e.png)
Old:
![Screen Shot 2020-06-15 at 4 55 53 PM](https://user-images.githubusercontent.com/47616998/84706648-57388d80-af2b-11ea-9b74-02fd047e78d8.png)

Compared session counts by category - made sure that the blogs total was the same as before. (for time frame after 9/1/2019)
Tested in Dev Mode.

## 👽 Other:
_Any additional information that might be useful!_
n/a